### PR TITLE
Fix small bug in Hop.Clone()

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -81,7 +81,7 @@ func (h *Hop) Clone() Hop {
 		res.Errors = append(res.Errors, e.Clone())
 	}
 
-	return *h
+	return res
 }
 
 type Error struct {


### PR DESCRIPTION
When cloning a Hop, *h is returned instead of res.  This means currently the deep copy of h.Errors is effectively bypassed.