### PR TITLE
context: Only add new KVs to the Context

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"slices"
 
 	"github.com/luno/jettison/models"
 )
@@ -30,10 +31,14 @@ func ContextWith(ctx context.Context, opts ...ContextOption) context.Context {
 }
 
 func ContextWithKeyValues(ctx context.Context, add []models.KeyValue) context.Context {
+	kvs := ContextKeyValues(ctx)
+	add = slices.DeleteFunc(add, func(kv models.KeyValue) bool {
+		return slices.Contains(kvs, kv)
+	})
 	if len(add) == 0 {
 		return ctx
 	}
-	kvs := append(ContextKeyValues(ctx), add...)
+	kvs = append(kvs, add...)
 	return context.WithValue(ctx, key, kvs)
 }
 

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -48,6 +48,24 @@ func TestContextWith(t *testing.T) {
 				{Key: "two", Value: "2"},
 			},
 		},
+		{
+			name: "dedupe kvs",
+			ctx: log.ContextWith(context.Background(), j.MKV{
+				"one": "1",
+				"two": "2",
+			}),
+			opts: []log.ContextOption{j.MKV{
+				"one":   "3!",
+				"two":   "2",
+				"three": "3",
+			}},
+			expKVs: []models.KeyValue{
+				{Key: "one", Value: "1"},
+				{Key: "two", Value: "2"},
+				{Key: "one", Value: "3!"},
+				{Key: "three", Value: "3"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This will de-duplicate identical key values that are added to the context. 
We still keep entries with same keys but different values.