### PR TITLE
log: Reduce allocated data in ContextKeyValues

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -62,7 +62,7 @@ func contextKV(ctx context.Context) []models.KeyValue {
 	if ctx == nil {
 		return nil
 	}
-	// nil will return false, and we can return an empty slice safely
+	// a nil return from Value will return false from the cast, we can return the empty slice safely
 	kvs, _ := ctx.Value(key).([]models.KeyValue)
 	return kvs
 }

--- a/log/context.go
+++ b/log/context.go
@@ -62,9 +62,7 @@ func contextKV(ctx context.Context) []models.KeyValue {
 	if ctx == nil {
 		return nil
 	}
+	// nil will return false, and we can return an empty slice safely
 	kvs, _ := ctx.Value(key).([]models.KeyValue)
-	if len(kvs) == 0 {
-		return nil
-	}
-	return ctx.Value(key).([]models.KeyValue)
+	return kvs
 }

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -75,3 +75,26 @@ func TestContextWith(t *testing.T) {
 		})
 	}
 }
+
+func TestChildDoesntChangeParent(t *testing.T) {
+	parent := log.ContextWith(context.Background(), j.KV("one", "1"))
+	child := log.ContextWith(parent, j.KV("two", "2"))
+
+	expParent := []models.KeyValue{{Key: "one", Value: "1"}}
+	assert.Equal(t, expParent, log.ContextKeyValues(parent))
+	expChild := []models.KeyValue{
+		{Key: "one", Value: "1"},
+		{Key: "two", Value: "2"},
+	}
+	assert.Equal(t, expChild, log.ContextKeyValues(child))
+}
+
+func BenchmarkContextWith(b *testing.B) {
+	b.ReportAllocs()
+	b.SetBytes(1)
+	ctx := log.ContextWith(context.Background(), j.KV("one", "1"))
+
+	for range b.N {
+		_ = log.ContextWith(ctx, j.KV("one", "1"))
+	}
+}


### PR DESCRIPTION
In this change, we avoid copying the KVs from the Context until we know we need a new slice (i.e. we have something to add)

BenchmarkContextWith before and after

**before**
```
goos: darwin
goarch: arm64
pkg: github.com/luno/jettison/log
cpu: Apple M3 Pro
BenchmarkContextWith
BenchmarkContextWith-11    	 4461908	       254.6 ns/op	   3.93 MB/s	     464 B/op	       7 allocs/op
PASS
```
**after**
```
goos: darwin
goarch: arm64
pkg: github.com/luno/jettison/log
cpu: Apple M3 Pro
BenchmarkContextWith
BenchmarkContextWith-11    	 4701661	       224.6 ns/op	   4.45 MB/s	     400 B/op	       5 allocs/op
PASS
```