### PR TITLE
github/workflows: Use Go version in go.mod rather than static version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.21', '1.22', '1']
+        go: ['1.24', '1']
 
     services:
       etcd:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Test
         run: make test
         env:
-          TESTING_ETCD_ENDPOINTS: "http://localhost:${{ job.services.etcd.ports[2379] }}"
+          TESTING_ETCD_ENDPOINTS: "http://localhost:${{ job.services.etcd.ports['2379'] }}"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
 
       - name: Generate Sonar Report
         run: go test -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json


### PR DESCRIPTION
Update GitHub Actions workflow to use standardized Go versions ['1.24', '1'] instead of ['1.21', '1.22', '1'].

This change:
- Uses Go 1.24 as the specific version for testing
- Uses Go '1' to always test against the latest stable version
- Removes older Go versions that are no longer needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - CI test matrix narrowed to current Go releases, reducing redundant test runs for more focused validation.

- Chores
  - Updated continuous-integration configuration to target supported Go versions and removed older versions; no runtime or user-facing behaviour changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->