### PR TITLE
chore: bump go.mod to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/jettison
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/dave/dst v0.27.3


### PR DESCRIPTION
Bump the `go` directive in `go.mod` to `1.26.0`.